### PR TITLE
fixes boot order for systemd unit

### DIFF
--- a/src/amdfan/amdfan.service
+++ b/src/amdfan/amdfan.service
@@ -1,9 +1,12 @@
 [Unit]
 Description=amdfan controller
+After=multi-user.target
+Requires=multi-user.target
 
 [Service]
 ExecStart=/usr/bin/amdfan --daemon
 Restart=always
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=final.target
+


### PR DESCRIPTION
On some systems, such as using the -hardened kernel, and with Gnome Display Manager, the service will fail if it runs before the GDM.

So we make it go last, and it works.