### PR TITLE
add better daemon support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ Options:
   --help         Show this message and exit.
 
 Commands:
-  daemon         Run the controller
+  daemon         Run the controller as a service
+  manage         Run the fan controller
   monitor        View the current temperature and speed
   print-default  Convenient defaults
   set            Manually override the fan speed

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ frequency: 5
 # - card0
 ```
 
-If a configuration file is not found, a default one will be generated. If you want to make any changes to the default config before running it the daemon first, run `amdfan print-default --configuration | sudo tee /etc/amdfan.yml` and do your changes from there.
+If a configuration file is not found, a default one will be generated. If you want to make any changes to the default config before running the daemon, run `amdfan print-default --configuration | sudo tee /etc/amdfan.yml` and do your changes from there.
 
 - `speed_matrix` (required): a list of thresholds `[temperature, speed]` which are interpolated to calculate the fan speed.
 - `threshold` (default `0`): allows for some leeway in temperatures, as to not constantly change fan speed

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ If a configuration file is not found, a default one will be generated. If you wa
 - `frequency` (default `5`): how often (in seconds) we wait between updates
 - `cards` (required): a list of card names (from `/sys/class/drm`) which we want to control.
 
-Note! You can send a **SIGHUP** signal to the daemon to request a reload of the config without restarting the whole service.
+Note! You can send a **SIGHUP** signal to the daemon to request a reload of the config without restarting the whole service. Additionally, if you're using a pidfile, you can send a signal to reload the config with `amdfan daemon --signal=reload`
 
 # Install
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ These are all addressed in Amdfan, and as long as I’ve still got some AMD card
 Usage: amdfan [OPTIONS] COMMAND [ARGS]...
 
 Options:
-  --help  Show this message and exit.
+  -v, --version  Show the version and exit.
+  --help         Show this message and exit.
 
 Commands:
   daemon         Run the controller

--- a/amdfan/__main__.py
+++ b/amdfan/__main__.py
@@ -3,7 +3,7 @@
 # __main__.py
 import click
 
-from .commands import cli, monitor_cards, run_daemon, set_fan_speed
+from .commands import cli, monitor_cards, run_daemon, run_manager, set_fan_speed
 
 
 @click.group()
@@ -13,6 +13,7 @@ def main():
 
 
 main.add_command(cli)
+main.add_command(run_manager)
 main.add_command(run_daemon)
 main.add_command(monitor_cards)
 main.add_command(set_fan_speed)

--- a/amdfan/__main__.py
+++ b/amdfan/__main__.py
@@ -7,6 +7,7 @@ from .commands import cli, monitor_cards, run_daemon, set_fan_speed
 
 
 @click.group()
+@click.version_option(None, "-v", "--version", prog_name="amdfan")
 def main():
     pass
 

--- a/amdfan/commands.py
+++ b/amdfan/commands.py
@@ -2,6 +2,7 @@
 """ entry point for amdfan """
 # noqa: E501
 import os
+import signal
 import sys
 import time
 from typing import Dict
@@ -122,7 +123,18 @@ def run_daemon(
         logfile = None
 
     if action:
-        pass  # nyi
+        try:
+            with open(pidfile) as f:
+                pid = int(f.read())
+                if action == "stop":
+                    os.kill(pid, signal.SIGTERM)
+                elif action == "reload":
+                    os.kill(pid, signal.SIGHUP)
+
+        except FileNotFoundError:
+            LOGGER.warning("Could not find pidfile=%s", pidfile)
+        except ValueError:
+            LOGGER.warning("Invalid PID value in pidfile=%s", pidfile)
     else:
         FanController.start_manager(
             notification_fd=notification_fd,

--- a/amdfan/commands.py
+++ b/amdfan/commands.py
@@ -155,8 +155,8 @@ def show_table(cards: Dict) -> Table:
 
 
 @click.command(name="monitor", help="View the current temperature and speed")
-@click.option("--fps", default=5, help="Updates per second")
-@click.option("--single-run", is_flag=True, default=False, help="Print and exit")
+@click.option("--fps", default=5, help="Updates per second", show_default=True)
+@click.option("-1", "--single-run", is_flag=True, default=False, help="Print and exit")
 def monitor_cards(fps, single_run) -> None:
     scanner = Scanner()
     if not single_run:
@@ -170,9 +170,25 @@ def monitor_cards(fps, single_run) -> None:
             time.sleep(1 / fps)
 
 
-@click.command(name="set", help="Manually override the fan speed")
-@click.option("--card", help="Specify which card to override")
-@click.option("--speed", help="Specify which speed to change to")
+class CardOpt(click.ParamType):
+    name = "CARD"
+
+
+class SpeedOpt(click.ParamType):
+    name = "SPEED"
+
+
+@click.command(
+    name="set",
+    short_help="Manually override the fan speed",
+    help="Manually override the fan speed.\n\nIf insufficient properties are passed, goes into interactive mode. If both values are valid, interactive mode is not necessary\n\nSpeed values are set with integer values representing a percentage, and can be reverted back to the automatic controller by setting the speed to 'auto'.",
+)
+@click.option("--card", type=CardOpt(), help="Specify which card to override")
+@click.option(
+    "--speed",
+    type=SpeedOpt(),
+    help="Specify which speed to change to",
+)
 def set_fan_speed(card, speed) -> None:
     scanner = Scanner()
     if card is None:

--- a/amdfan/commands.py
+++ b/amdfan/commands.py
@@ -95,9 +95,10 @@ class FileDescriptorOpt(click.ParamType):
     show_default=True,
 )
 @click.option(
+    "--stdout",
     "--no-logfile",
     is_flag=True,
-    help="Disable logging file",
+    help="Disable logging file (prints to stdout instead)",
 )
 @click.option(
     "-b",

--- a/amdfan/commands.py
+++ b/amdfan/commands.py
@@ -78,13 +78,13 @@ class FileDescriptorOpt(click.ParamType):
     "-p",
     type=click.Path(),
     default=os.path.join(PIDFILE_DIR, "amdfan.pid"),
-    help=f"Pidfile path",
+    help="Pidfile path",
     show_default=True,
 )
 @click.option(
     "--no-pidfile",
     is_flag=True,
-    help=f"Disable pidfile",
+    help="Disable pidfile",
 )
 @click.option(
     "-l",
@@ -95,8 +95,8 @@ class FileDescriptorOpt(click.ParamType):
     show_default=True,
 )
 @click.option(
-    "--stdout",
     "--no-logfile",
+    "--stdout",
     is_flag=True,
     help="Disable logging file (prints to stdout instead)",
 )

--- a/amdfan/controller.py
+++ b/amdfan/controller.py
@@ -246,15 +246,19 @@ class FanController:  # pylint: disable=too-few-public-methods
         self._stop_event = threading.Event()
 
     def reload_config(self, *_) -> None:
+        LOGGER.info("Received request to reload config")
         self.load_config()
 
     def terminate(self, *_) -> None:
+        LOGGER.info("Shutting down controller")
         self._running = False
         self._stop_event.set()
 
     def load_config(self) -> None:
+        LOGGER.info("Loading configuration")
         config = load_config(self.config_path)
         self.apply(config)
+        LOGGER.info("Configuration succesfully loaded")
 
     def apply(self, config) -> None:
         self._scanner = Scanner(config.get("cards"))
@@ -350,6 +354,7 @@ class FanController:  # pylint: disable=too-few-public-methods
         for location in CONFIG_LOCATIONS:
             if os.path.isfile(location):
                 config_path = location
+                LOGGER.info("Found configuration file at %s", config_path)
                 break
 
         if config_path is None:

--- a/amdfan/controller.py
+++ b/amdfan/controller.py
@@ -6,8 +6,7 @@ import re
 import signal
 import sys
 import threading
-import time
-from typing import Any, Callable, Dict, List, Optional, Self
+from typing import Any, Callable, Dict, List, Optional
 
 import numpy as np
 import yaml
@@ -41,7 +40,7 @@ def daemonize(stdin="/dev/null", stdout="/dev/null", stderr="/dev/null") -> None
         if pid > 0:
             os._exit(0)
     except OSError as e:
-        raise Exception("Unable to background amdfan")
+        raise Exception("Unable to background amdfan: %s" % e)
 
     os.chdir("/")
     os.setsid()
@@ -52,7 +51,7 @@ def daemonize(stdin="/dev/null", stdout="/dev/null", stderr="/dev/null") -> None
         if pid > 0:
             os._exit(0)
     except OSError as e:
-        raise Exception("Unable to daemonize amdfan")
+        raise Exception("Unable to daemonize amdfan: %s" % e)
 
     redirect_fd(stdin, stdout, stderr)
 

--- a/dist/openrc/amdfan.in
+++ b/dist/openrc/amdfan.in
@@ -1,10 +1,13 @@
 #!/sbin/openrc-run
 
 description="amdfan controller"
-command="@bindir@/amdfan"
-command_args="--daemon"
-command_background=true
 pidfile="/var/run/${RC_SVCNAME}.pid"
+
+command="@bindir@/amdfan"
+command_args="daemon --logfile=/var/log/amdfan.log --pidfile=${pidfile}"
+command_args_background="--background"
+
+extra_started_commands="reload"
 
 reload() {
 	start-stop-daemon --signal SIGHUP --pidfile "${pidfile}"


### PR DESCRIPTION
As I mentioned in issue #36 , I wanted to add support for running the service in the background. This PR does just that, and also adds some cleaner shutdown to the controller. I've added some better logging statements and better --help documentation.

Keep in mind the logger is using the same logger as it used to on the terminal, meaning the rich colours we see may be interpreted weirdly by some editors when viewing them. That said, I feel like if that's an issue for some people, that's the user's editor's issue, and not really our fault. If this is a problem, we may choose to add some configuration to it (as we might want to do with the verbosity, fwiw).

The main changes is that `amdfan daemon` by default now redirects the output to `/var/log/amdfan.log`. This can be reverted with `--no-logfile` or `--stdout`, or a manual logfile can be set with `--logfile=`. 

After some discussion with some init-smart people, I decided that it's better to explicitly request the daemon to run in the background with `--background`. By default it will stay running in the foreground, as expected by most init systems.

Some commits include more details

Closes: #36 