### PR TITLE
Fix amdfan service not starting: edit amdfan.service.in

### DIFF
--- a/dist/systemd/amdfan.service.in
+++ b/dist/systemd/amdfan.service.in
@@ -9,5 +9,5 @@ ExecReload=kill -HUP $MAINPID
 Restart=always
 
 [Install]
-WantedBy=final.target
+WantedBy=graphical.target
 


### PR DESCRIPTION
According to systemd documentation, _final.target_ is

> a special target unit that is used during the shutdown logic and may be used to pull in late services after all normal services are already terminated and all mounts unmounted.

Having the WantedBy=final.target section in the service description thus leads to amdfan **not starting at all** in multi-user.target or graphical.target and instead only during system shutdown, which for sure isn't intended.

As such, change the entry in the service description to _WantedBy=graphical.target_, which actually allows the enabled service to be started when entering graphical mode and thus yield a behavior that is more in line with users' expectations.
