### PR TITLE
error handling

### DIFF
--- a/amdfan/commands.py
+++ b/amdfan/commands.py
@@ -220,7 +220,11 @@ def set_fan_speed(card, speed) -> None:
         selected_card.set_system_controlled_fan(True)
     else:
         LOGGER.info("Setting fan speed to %d", int(input_fan_speed))
-        c.print(selected_card.set_fan_speed(int(input_fan_speed)))
+        try:
+            bytes_written = selected_card.set_fan_speed(int(input_fan_speed))
+            c.print(bytes_written)
+        except RuntimeError:
+            sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/amdfan/controller.py
+++ b/amdfan/controller.py
@@ -137,7 +137,7 @@ class Card:
         try:
             self._verify_card()
         except FileNotFoundError:
-            LOGGER.warning(f"{self._id} is missing expected endpoints!")
+            LOGGER.warning("%s is missing expected endpoints!", self._id)
 
     def _verify_card(self) -> None:
         missing = []
@@ -162,7 +162,7 @@ class Card:
             with open(self._endpoints[endpoint], "r", encoding="utf8") as endpoint_file:
                 return endpoint_file.read()
         except KeyError as e:
-            LOGGER.error(f"Failed to find endpoint {endpoint} for {self._id}.\nDoes {self._dir} support the requested control?")
+            LOGGER.error("Failed to find endpoint %s for %s.\nDoes %s support the requested control?", endpoint, self._id, self._dir)
             self.broken_read = True
             raise ValueError(e)
 
@@ -177,7 +177,7 @@ class Card:
             self.broken_write = False
             raise e
         except KeyError as e:
-            LOGGER.error(f"Failed to find endpoint {endpoint} for {self._id}.\nDoes {self._dir} support the requested control?")
+            LOGGER.error("Failed to find endpoint %s for %s.\nDoes %s support the requested control?", endpoint, self._id, self._dir)
             self.broken_write = True
             raise ValueError(e)
 
@@ -316,10 +316,10 @@ class FanController:  # pylint: disable=too-few-public-methods
                     self.refresh_card(name, card)
                 except RuntimeError:
                     if card.broken_read:
-                        LOGGER.error(f"Removing {name} from runtime as unable to monitor it")
+                        LOGGER.error("Removing %s from runtime as unable to monitor it", name)
                         self._scanner.cards.pop(name)
                     elif card.broken_write:
-                        LOGGER.warning(f"Entering read-only mode for {name}. Only thermal readings will be provided.")
+                        LOGGER.warning("Entering read-only mode for %s. Only thermal readings will be provided.", name)
 
             self._stop_event.wait(self._frequency)
 
@@ -334,7 +334,7 @@ class FanController:  # pylint: disable=too-few-public-methods
 
             elif self._permit_monitor_only == "always":
                 count = sum(card.broken_write for card in self._scanner.cards.values())
-                LOGGER.info(f"Found {count} cards in read-only mode, from a total of {len(self._scanner.cards)}")
+                LOGGER.info("Found %d cards in read-only mode, from a total of %d cards", count, len(self._scanner.cards))
 
         LOGGER.info("Stopped controller")
 

--- a/amdfan/defaults.py
+++ b/amdfan/defaults.py
@@ -31,6 +31,12 @@ speed_matrix:
 # cards:
 # can be any card returned from `ls /sys/class/drm | grep "^card[[:digit:]]$"`
 # - card0
+#
+# How should we handle misbehaving cards?
+# - `auto` will only exit when there's no writable cards. Can be useful if you have multiple cards, and you know one of them is misbehaving.
+# - `never` will exit even if one card is broken. This is perhaps the safest, as your service will detect crashing.
+# - `always` will ignore any cards we can't write to. Might be useful if you only want to use amdfan as a monitor, and controlling it elsewhere.
+# permit_monitor_only: auto
 """
 
 SERVICES: Dict[str, str] = {


### PR DESCRIPTION
As mentioned in #44 , we would raise a python exception if things break. I've implemented support for working in a read-only state (configurable), and have caught these exceptions to log error messages that should be more helpful to the user.

I've also taken the opportunity to handle verifying the configuration file, so attempting to reload a running service after breaking the config should keep running.

I haven't implemented any specific probe-config command, do you think we should?

Closes #44

PS: I haven't looked into LACT yet, no updates on that note.